### PR TITLE
Feat: 팔로우 연동 및 프로필 이동 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -139,6 +139,7 @@ function AppLayout() {
             <Route path="/profile/edit" element={<ProfileEditPage />} />
             <Route path="/profile/settings" element={<SettingsPage />} />
             <Route path="/users/me" element={<ProfilePage />} />
+            <Route path="/profile/:id" element={<ProfilePage />} /> 
 
              {/* 반려견 */}
             <Route path="/dogs/add" element={<DogAddPage />} />

--- a/src/components/common/UserProfileLink.jsx
+++ b/src/components/common/UserProfileLink.jsx
@@ -1,0 +1,40 @@
+import { useNavigate } from "react-router-dom";
+
+/**
+ * 유저 프로필 이동을 위한 공통 링크 컴포넌트
+ * userId가 null/undefined → 내 프로필(/profile)
+ * userId가 숫자/문자열 → 상대 프로필(/profile/{id})
+ *
+ * 사용 예:
+ * <UserProfileLink userId={user.id}>
+ *   <img src={user.profileImage} />
+ *   <span>{user.nickname}</span>
+ * </UserProfileLink>
+ */
+export default function UserProfileLink({ userId, children, className = "" }) {
+  const navigate = useNavigate();
+
+  const handleClick = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    // null 또는 undefined → 내 프로필
+    if (userId == null) {
+      navigate("/profile");
+    } else {
+      navigate(`/profile/${userId}`);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`cursor-pointer inline-flex items-center bg-transparent border-none p-0 ${className}`}
+      onClick={handleClick}
+      style={{ appearance: "none" }}
+      aria-label="프로필로 이동"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/pages/Profile/ProfilePage.jsx
+++ b/src/pages/Profile/ProfilePage.jsx
@@ -1,33 +1,39 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { getMyInfo } from "@/services/userService";
+import { useNavigate, useParams } from "react-router-dom";
+import { getMyInfo, getUserInfo } from "@/services/userService";
+import { followUser, unfollowUser } from "@/services/followService";
+
 import ProfileFreePage from "./ProfileFreePage";
 import ProfileWalkPage from "./ProfileWalkPage";
 import ProfileAccompanyManagePage from "./ProfileAccompanyManagePage";
 
 export default function ProfilePage() {
   const navigate = useNavigate();
+  const { id } = useParams(); // URL 파라미터 (다른 유저 프로필일 때 사용)
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState("free");
+
+  // 로컬 유저 (내 정보)
   const localUser = JSON.parse(localStorage.getItem("user"));
   const totalPoint = localUser?.totalPoint ?? 0;
 
+  // 내 프로필인지 판별 (URL id와 localUser.id 비교)
+  const isMyProfile = !id || Number(id) === Number(localUser?.id);
+
   useEffect(() => {
     const token = localStorage.getItem("token");
-
     if (!token) {
       navigate("/login");
       return;
     }
 
-    const fetchUser = async () => {
+    const fetchProfile = async () => {
       try {
-        const data = await getMyInfo();
+        const data = id ? await getUserInfo(id) : await getMyInfo();
         setUser(data);
       } catch (err) {
-        console.error("유저 조회 실패:", err);
-
+        console.error("프로필 조회 실패:", err);
         if (err.response?.status === 401) {
           localStorage.removeItem("token");
           navigate("/login");
@@ -37,15 +43,14 @@ export default function ProfilePage() {
       }
     };
 
-    fetchUser();
-  }, [navigate]);
+    fetchProfile();
+  }, [id, navigate]);
 
   if (loading) return <p className="text-center mt-10">로딩 중...</p>;
   if (!user) return null;
 
   return (
     <div className="w-full min-h-screen bg-[#FFFDF6]">
-      {/* 프로필 전체 블록 */}
       <div className="px-5 pt-10 flex items-start gap-6">
         {/* 프로필 이미지 */}
         <div className="relative w-24 h-24 flex-shrink-0">
@@ -54,28 +59,52 @@ export default function ProfilePage() {
             className="w-full h-full rounded-full object-cover border border-gray-200"
           />
 
-          {/* 수정 아이콘 */}
-          <button
-            onClick={() => navigate("/profile/edit")}
-            className="
-              absolute bottom-0 right-0 
-              w-9 h-9 bg-[#F6C343] rounded-full shadow 
-              flex items-center justify-center overflow-hidden
-            "
-          >
-            <img src="/Edit.svg" className="w-[60%]" />
-          </button>
+          {/* 내 프로필일 때만 수정 버튼 보임 */}
+          {isMyProfile && (
+            <button
+              onClick={() => navigate("/profile/edit")}
+              className="
+                absolute bottom-0 right-0 
+                w-9 h-9 bg-[#F6C343] rounded-full shadow 
+                flex items-center justify-center overflow-hidden
+              "
+            >
+              <img src="/Edit.svg" className="w-[60%]" />
+            </button>
+          )}
         </div>
 
-        {/* 닉네임/소개/기록 */}
+        {/* 닉네임 / 자기소개 / 팔로우 */}
         <div className="flex flex-col w-full">
-          {/* 닉네임 + 팔로우 */}
           <div className="flex items-center justify-between">
             <p className="text-2xl font-bold text-[#4C3728]">{user.nickname}</p>
 
-            <button className="px-6 py-2 bg-[#EDA258] text-white rounded-full text-lg font-semibold">
-              팔로우
-            </button>
+            {/* 내 프로필이 아닐 때만 팔로우 버튼 표시 */}
+            {!isMyProfile && (
+              <button
+                onClick={async () => {
+                  try {
+                    if (user.isFollowing) {
+                      await unfollowUser(user.id);
+                    } else {
+                      await followUser(user.id);
+                    }
+                    const updated = await getUserInfo(user.id);
+                    setUser(updated);
+                  } catch (err) {
+                    console.error("팔로우/언팔 오류:", err);
+                  }
+                }}
+                className={`px-6 py-2 rounded-full text-lg font-semibold 
+                  ${
+                    user.isFollowing
+                      ? "bg-gray-300 text-[#4C3728]"
+                      : "bg-[#EDA258] text-white"
+                  }`}
+              >
+                {user.isFollowing ? "언팔로우" : "팔로우"}
+              </button>
+            )}
           </div>
 
           {/* 자기소개 */}
@@ -83,7 +112,7 @@ export default function ProfilePage() {
             {user.bio || "자기소개를 입력해 보세요!"}
           </p>
 
-          {/* 기록 / 팔로워 / 팔로잉 */}
+          {/* 기록 · 팔로워 · 팔로잉 · 포인트 */}
           <div className="mt-4 flex flex-row items-center gap-10">
             <div className="text-center">
               <p className="text-lg font-semibold">{user.recordCount ?? 0}</p>
@@ -94,18 +123,19 @@ export default function ProfilePage() {
               <p className="text-xs text-[#B38A6A]">팔로워</p>
             </div>
             <div className="text-center">
-              <p className="text-lg font-semibold">
-                {user.followingCount ?? 0}
-              </p>
+              <p className="text-lg font-semibold">{user.followingCount ?? 0}</p>
               <p className="text-xs text-[#B38A6A]">팔로잉</p>
             </div>
 
-            <div className="flex items-center gap-1">
-              <p className="text-xs text-[#B38A6A]">💰 적립 포인트</p>
-              <p className="text-sm font-semibold text-[#B5802A]">
-                {totalPoint} P
-              </p>
-            </div>
+            {/* 포인트는 내 프로필에서만 표시 */}
+            {isMyProfile && (
+              <div className="flex items-center gap-1">
+                <p className="text-xs text-[#B38A6A]">💰 적립 포인트</p>
+                <p className="text-sm font-semibold text-[#B5802A]">
+                  {totalPoint} P
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -113,7 +143,7 @@ export default function ProfilePage() {
       {/* 반려견 영역 */}
       <div className="mt-1 px-5">
         <p className="text-base font-semibold text-[#6B5B4A] mb-3">
-          나의 반려동물 🐾
+          {isMyProfile ? "나의 반려동물 🐾" : "반려동물 🐾"}
         </p>
 
         {(user.dogs ?? []).length > 0 ? (
@@ -132,37 +162,39 @@ export default function ProfilePage() {
                     style={{ transformOrigin: "center" }}
                   />
                 </div>
-
                 <p className="text-xs text-[#6B5B4A] mt-1">{dog.name}</p>
               </div>
             ))}
 
-            {/* + 버튼도 동일한 구조로 감싸기 */}
-            <div className="flex flex-col items-center">
+            {/* 내 프로필일 때만 반려견 추가 버튼 표시 */}
+            {isMyProfile && (
+              <div className="flex flex-col items-center">
+                <button
+                  onClick={() => navigate("/dogs/add")}
+                  className="w-16 h-16 rounded-full bg-[#F3E9D2] flex items-center justify-center shadow"
+                >
+                  <span className="text-[#D4A055] text-3xl font-bold">+</span>
+                </button>
+                <p className="text-xs text-[#F3E9D2] mt-1"> </p>
+              </div>
+            )}
+          </div>
+        ) : (
+          isMyProfile && (
+            <div className="flex flex-col items-start gap-3">
               <button
                 onClick={() => navigate("/dogs/add")}
-                className="w-16 h-16 rounded-full bg-[#F3E9D2] flex items-center justify-center shadow"
+                className="w-14 h-14 rounded-full bg-[#F3E9D2] flex items-center justify-center shadow"
               >
                 <span className="text-[#D4A055] text-3xl font-bold">+</span>
               </button>
-              <p className="text-xs text-[#F3E9D2] mt-1"> </p>
             </div>
-          </div>
-        ) : (
-          <div className="flex flex-col items-start gap-3">
-            <button
-              onClick={() => navigate("/dogs/add")}
-              className="w-14 h-14 rounded-full bg-[#F3E9D2] flex items-center justify-center shadow"
-            >
-              <span className="text-[#D4A055] text-3xl font-bold">+</span>
-            </button>
-          </div>
+          )
         )}
       </div>
 
       {/* 탭 메뉴 */}
       <div className="flex px-5 mt-8 border-b border-[#F4E4C2]">
-        {/* 자유 */}
         <button
           className={`px-4 pb-3 text-sm ${
             tab === "free"
@@ -174,7 +206,6 @@ export default function ProfilePage() {
           자유
         </button>
 
-        {/* 산책 */}
         <button
           className={`px-4 pb-3 text-sm ${
             tab === "walk"
@@ -186,7 +217,6 @@ export default function ProfilePage() {
           산책
         </button>
 
-        {/* 동행 */}
         <button
           className={`px-4 pb-3 text-sm ${
             tab === "accompany"
@@ -199,7 +229,7 @@ export default function ProfilePage() {
         </button>
       </div>
 
-      {/* 🔶 탭별 렌더링 */}
+      {/* 탭 렌더링 */}
       <div className="mt-5 px-5">
         {tab === "free" && <ProfileFreePage user={user} />}
         {tab === "walk" && <ProfileWalkPage user={user} />}

--- a/src/pages/companion/CompanionDetailPage.jsx
+++ b/src/pages/companion/CompanionDetailPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { ArrowLeft, Pencil, Trash } from "lucide-react";
 import UserAvatar from "../../components/ui/UserAvatar";
+import UserProfileLink from "../../components/common/UserProfileLink";
 
 <style>{`
   @keyframes fadeIn {
@@ -338,12 +339,20 @@ export default function CompanionDetailPage() {
             <div className="mb-4 flex flex-col gap-2 text-sm text-gray-500">
               {/* 첫 줄: 작성자 + 버튼들 */}
               <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
+                {/* <div className="flex items-center gap-2">
                   <UserAvatar image={companion.user?.image} size="md" />
                   <span className="font-medium">
                     {companion.user?.nickname || "익명"}
                   </span>
-                </div>
+                </div> */}
+                <UserProfileLink userId={companion.user?.id}>
+                  <div className="flex items-center gap-2 cursor-pointer">
+                    <UserAvatar image={companion.user?.image} size="md" />
+                    <span className="font-medium">
+                      {companion.user?.nickname || "익명"}
+                    </span>
+                  </div>
+                </UserProfileLink>
 
                 <div className="flex gap-2">
                   {currentUserId !== companion.user?.id ? (

--- a/src/services/followService.js
+++ b/src/services/followService.js
@@ -1,0 +1,13 @@
+import api from "./api";
+
+// 팔로우 
+export const followUser = async (userId) => {
+  const res = await api.post(`/follows/${userId}`);
+  return res.data;
+};
+
+// 언팔로우
+export const unfollowUser = async (userId) => {
+  const res = await api.delete(`/follows/${userId}`);
+  return res.data;
+};

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -6,8 +6,18 @@ export const getMyInfo = async () => {
   return res.data;
 };
 
-// 내 정보 수정
+// 다른 유저 정보 조회 (프로필 방문 시 사용)
+export const getUserInfo = async (userId) => {
+  const res = await api.get(`/users/${userId}`);
+  return res.data;
+};
+
+// 내 정보 수정 (이미지 + 닉네임 + 자기소개)
 export const updateUserInfo = async (formData) => {
-  const res = await api.patch("/users/me", formData);
+  const res = await api.patch("/users/me", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
   return res.data;
 };


### PR DESCRIPTION
> ### 🔍 관련 이슈
- closes #30 

> ### 🧩 PR 요약
- 팔로우/언팔로우 기능 연동
- 유저 프로필 페이지 이동 기능 구현
- 동행 상세 페이지에서 작성자 프로필 클릭 시 이동 추가

> ### 🧱 변경 사항
- UserProfileLink 컴포넌트 추가
- ProfilePage 팔로우 UI 및 isFollowing 분기 처리  
 내 프로필: 프로필 수정 버튼 + 포인트 표시, 팔로우 버튼 미표시
 다른 사용자 프로필: 팔로우/언팔로우 버튼 표시
- CompanionDetailPage 작성자 프로필 이동 처리
- followService 추가 및 userService 연동

> ### 🧪 테스트 결과

<img width="501" height="850" alt="스크린샷 2025-11-20 오후 7 01 35" src="https://github.com/user-attachments/assets/6fcee5a1-8efb-4430-97dc-cf4032c90739" />
<img width="523" height="834" alt="스크린샷 2025-11-20 오후 7 01 23" src="https://github.com/user-attachments/assets/2a6e623e-76ec-40a6-a01e-c2ef1b9d6c9c" />

> ### 🧠 참고 사항
지금은 팔로우/ 언팔로우 기본적인 기능만 가능합니다
팔로우 목록/리스트 페이지는 추후 추가 하겠습니다