### PR TITLE
Feat: 댓글, 좋아요 UI 추가

### DIFF
--- a/src/pages/community/CommunityCard.jsx
+++ b/src/pages/community/CommunityCard.jsx
@@ -1,4 +1,5 @@
 import UserAvatar from "../../components/ui/UserAvatar";
+import { Heart, MessageCircle } from "lucide-react";
 
 export default function CommunityCard({
   title,
@@ -6,6 +7,8 @@ export default function CommunityCard({
   image,
   user,
   onClick,
+  likeCount,
+  commentCount,
 }) {
   // 🔪 글자수 제한 처리
   const MAX_TITLE_LENGTH = 15; // 원하는 글자수로 변경 가능
@@ -51,6 +54,16 @@ export default function CommunityCard({
             <span className="text-xs font-medium text-text">
               {user.nickname}
             </span>
+          </div>
+          <div className="flex items-center gap-4 text-gray-500 text-xs">
+            <div className="flex items-center gap-1">
+              <Heart size={14} className="text-red-500" />
+              <span>{likeCount}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <MessageCircle size={14} className="text-blue-500" />
+              <span>{commentCount}</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/community/CommunityDetailPage.jsx
+++ b/src/pages/community/CommunityDetailPage.jsx
@@ -1,46 +1,97 @@
+// src/pages/community/CommunityDetailPage.jsx
 import React, { useEffect, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Pencil, Trash } from "lucide-react";
+import { ArrowLeft, Pencil, Trash, Heart } from "lucide-react";
+
 import UserAvatar from "../../components/ui/UserAvatar";
 import UserProfileLink from "../../components/common/UserProfileLink";
 
-<style>{`
-  @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-4px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-  .animate-fadeIn {
-    animation: fadeIn 0.2s ease-out;
-  }
-`}</style>;
+import {
+  getCommunityDetail,
+  deleteCommunity,
+} from "../../services/communityService";
+
+import {
+  getComments,
+  createComment,
+  updateComment,
+  deleteComment,
+} from "../../services/commentService";
 
 export default function CommunityDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+
   const [community, setCommunity] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [newComment, setNewComment] = useState("");
+  const [replyTargetId, setReplyTargetId] = useState(null);
+  const [replyContent, setReplyContent] = useState("");
+  const [editingCommentId, setEditingCommentId] = useState(null);
+  const [editingContent, setEditingContent] = useState("");
 
   const currentUserId = Number(JSON.parse(localStorage.getItem("user"))?.id);
-
-  // ✅ 글 상세 불러오기
   const fetchedRef = useRef(false);
+
+  const handleToggleLike = async () => {
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/community/${id}/like`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
+
+      const data = await res.json();
+
+      setCommunity((prev) => ({
+        ...prev,
+        likeCount: data.likeCount,
+        liked: data.isLiked,
+      }));
+    } catch (err) {
+      console.error("좋아요 실패:", err);
+    }
+  };
 
   useEffect(() => {
     if (fetchedRef.current) return;
     fetchedRef.current = true;
 
-    const fetchCommunity = async () => {
-      const res = await fetch(
-        `${import.meta.env.VITE_API_BASE_URL}/community/${id}`,
-        {
-          credentials: "include",
-        }
-      );
-      const data = await res.json();
-      setCommunity(data);
+    const loadData = async () => {
+      try {
+        // 📌 게시글 상세 (axios)
+        const post = await getCommunityDetail(id);
+        setCommunity(post);
+
+        // 📌 댓글 조회 (fetch)
+        const commentPage = await getComments(id, 0, 10);
+        setComments(commentPage.content);
+      } catch (err) {
+        console.error("불러오기 실패:", err);
+      }
     };
 
-    fetchCommunity();
+    loadData();
   }, []);
+
+  // 댓글 작성
+  const handleSubmitComment = async () => {
+    if (!newComment.trim()) return alert("댓글을 입력하세요.");
+
+    await createComment({
+      communityId: Number(id),
+      content: newComment,
+    });
+
+    const refreshed = await getComments(id, 0, 10);
+    setComments(refreshed.content);
+
+    setNewComment("");
+  };
 
   if (!community)
     return (
@@ -49,9 +100,113 @@ export default function CommunityDetailPage() {
       </div>
     );
 
+  // Recursive comment renderer
+  const renderComment = (comment, depth) => {
+    return (
+      <div
+        className="border-b border-gray-100 py-3"
+        style={{ marginLeft: depth * 16 }}
+      >
+        <div className="flex items-center mb-1">
+          <UserAvatar image={comment.profileImage} size="sm" />
+          <span className="ml-2 font-medium">{comment.nickname}</span>
+        </div>
+        <p className="ml-1 text-gray-700">{comment.content}</p>
+
+        <div className="flex items-center gap-3 ml-1 mt-1">
+          <button
+            onClick={() =>
+              setReplyTargetId(replyTargetId === comment.id ? null : comment.id)
+            }
+            className="text-xs text-blue-500 hover:underline"
+          >
+            답글
+          </button>
+
+          {Number(
+            localStorage.getItem("user") &&
+              JSON.parse(localStorage.getItem("user")).id
+          ) === comment.userId && (
+            <button
+              className="text-gray-400 hover:text-red-500 ml-auto"
+              onClick={async () => {
+                await deleteComment(comment.id);
+                const refreshed = await getComments(id, 0, 10);
+                setComments(refreshed.content);
+              }}
+            >
+              <Trash size={16} />
+            </button>
+          )}
+        </div>
+
+        {/* 수정 입력창 */}
+        {editingCommentId === comment.id && (
+          <div className="mt-2 ml-2 flex gap-2">
+            <input
+              className="flex-1 p-2 border border-gray-200 rounded-lg focus:border-gray-300"
+              value={editingContent}
+              onChange={(e) => setEditingContent(e.target.value)}
+            />
+            <button
+              onClick={async () => {
+                await updateComment(comment.id, { content: editingContent });
+                const refreshed = await getComments(id, 0, 10);
+                setComments(refreshed.content);
+                setEditingCommentId(null);
+                setEditingContent("");
+              }}
+              className="px-3 py-2 bg-primary text-white rounded-lg text-sm"
+            >
+              저장
+            </button>
+          </div>
+        )}
+
+        {replyTargetId === comment.id && (
+          <div className="mt-2 ml-2 flex gap-2">
+            <input
+              className="flex-1 p-2 border border-gray-200 rounded-lg focus:border-gray-300"
+              placeholder="답글을 입력하세요..."
+              value={replyContent}
+              onChange={(e) => setReplyContent(e.target.value)}
+            />
+            <button
+              onClick={async () => {
+                await createComment({
+                  communityId: Number(id),
+                  parentId: comment.id,
+                  content: replyContent,
+                });
+
+                const refreshed = await getComments(id, 0, 10);
+                setComments(refreshed.content);
+
+                setReplyContent("");
+                setReplyTargetId(null);
+              }}
+              className="px-3 py-2 bg-primary text-white rounded-lg text-sm"
+            >
+              등록
+            </button>
+          </div>
+        )}
+
+        {comment.children &&
+          comment.children.length > 0 &&
+          comment.children.map((child) => (
+            <React.Fragment key={child.id}>
+              {renderComment(child, depth + 1)}
+            </React.Fragment>
+          ))}
+      </div>
+    );
+  };
+
   return (
     <div className="min-h-screen bg-white text-text font-sans flex justify-center">
-      <div className="w-full sm:max-w-[500px] flex flex-col relative mx-auto h-screen">
+      <div className="w-full sm:max-w-[500px] flex flex-col relative mx-auto h-screen bg-[#FFF8EE]">
+        {/* 상단 헤더 */}
         <div className="sticky top-0 bg-[#FFF8EE] z-30 flex items-center gap-3 p-4 shadow-sm border-b border-gray-200">
           <button
             onClick={() => navigate(-1)}
@@ -60,12 +215,14 @@ export default function CommunityDetailPage() {
             <ArrowLeft className="text-gray-700" size={22} />
           </button>
           <h2 className="text-lg font-semibold text-gray-800">
-            동행 글 상세보기
+            커뮤니티 글 상세보기
           </h2>
         </div>
 
+        {/* 내용 영역 */}
         <main className="flex-1 overflow-y-auto pb-28 bg-[#FFF8EE]">
-          <div className="p-4">
+          {/* 이미지 */}
+          <div className="px-4 pt-6">
             {community.imageUrl && (
               <img
                 src={community.imageUrl}
@@ -75,83 +232,106 @@ export default function CommunityDetailPage() {
             )}
           </div>
 
-          <div className="bg-white/80 rounded-xl shadow-sm border border-gray-100 p-4 mx-4">
-            <h1 className="text-2xl font-bold text-gray-800 mb-2 flex items-start justify-between gap-3">
-              <span className="flex-1 break-words leading-snug">
-                {community.title}
-              </span>
+          {/* 본문 카드 */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mx-4 mt-4">
+            {/* 제목 */}
+            <h1 className="text-2xl font-bold text-gray-800 mb-2">
+              {community.title}
             </h1>
 
+            {/* 작성자 */}
             <div className="mb-4 flex flex-col gap-2 text-sm text-gray-500">
-              {/* 첫 줄: 작성자 + 버튼들 */}
-              <div className="flex items-center justify-between">
-                <UserProfileLink userId={community.user?.id}>
-                  <div className="flex items-center gap-2 cursor-pointer">
-                    <UserAvatar image={community.user?.image} size="md" />
-                    <span className="font-medium">
-                      {community.user?.nickname || "익명"}
-                    </span>
-                  </div>
-                </UserProfileLink>
-              </div>
+              <UserProfileLink userId={community.user.id}>
+                <div className="flex items-center gap-2 cursor-pointer">
+                  <UserAvatar image={community.user.image} size="md" />
+                  <span className="font-medium">{community.user.nickname}</span>
+                </div>
+              </UserProfileLink>
 
-              {/* 두 번째 줄: 등록 날짜 */}
               <span>
-                {new Date(community.registeredAt).toLocaleString([], {
-                  year: "numeric",
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
+                {new Date(community.registeredAt).toLocaleString("ko-KR")}
               </span>
-              <span>조회수: {community.views}</span>
+              {/* <span>조회수 {community.views}</span> */}
             </div>
 
-            <p className="text-gray-700 text-base leading-relaxed whitespace-pre-line">
+            {/* 내용 */}
+            <p className="text-gray-700 leading-relaxed whitespace-pre-line">
               {community.content}
             </p>
 
-            <div className="flex items-center gap-2 mt-3">
-              {currentUserId === community.user?.id && (
-                <>
-                  <button
-                    onClick={() => navigate(`/community/edit/${id}`)}
-                    className="text-gray-400 hover:text-blue-500 transition-colors duration-200 flex items-center justify-center"
-                  >
-                    <Pencil size={20} />
-                  </button>
+            {/* 수정 / 삭제 */}
+            {currentUserId === community.user.id && (
+              <div className="flex items-center gap-2 mt-6">
+                <button
+                  onClick={() => navigate(`/community/edit/${id}`)}
+                  className="text-gray-400 hover:text-blue-500"
+                >
+                  <Pencil size={20} />
+                </button>
 
-                  <button
-                    onClick={async () => {
-                      if (!window.confirm("정말 삭제하시겠습니까?")) return;
-                      try {
-                        const res = await fetch(
-                          `${
-                            import.meta.env.VITE_API_BASE_URL
-                          }/community/${id}`,
-                          {
-                            method: "DELETE",
-                            headers: {
-                              Authorization: `Bearer ${localStorage.getItem(
-                                "token"
-                              )}`,
-                            },
-                          }
-                        );
-                        if (!res.ok) throw new Error("삭제 실패");
-                        alert("삭제가 완료되었습니다.");
-                        navigate("/community");
-                      } catch (error) {
-                        console.error("삭제 오류:", error);
-                        alert("삭제 중 문제가 발생했습니다.");
-                      }
-                    }}
-                    className="text-gray-400 hover:text-red-500 transition-colors duration-200 flex items-center justify-center"
-                  >
-                    <Trash size={20} />
-                  </button>
-                </>
+                <button
+                  className="text-gray-400 hover:text-red-500"
+                  onClick={async () => {
+                    if (!window.confirm("삭제하시겠습니까?")) return;
+                    await deleteCommunity(id);
+                    navigate("/community");
+                  }}
+                >
+                  <Trash size={20} />
+                </button>
+              </div>
+            )}
+
+            {/* 좋아요 버튼 */}
+            <div className="mt-4 flex items-center gap-2">
+              <button
+                disabled={!localStorage.getItem("token")}
+                onClick={handleToggleLike}
+                className={`flex items-center gap-1 ${
+                  !localStorage.getItem("token")
+                    ? "opacity-50 cursor-not-allowed"
+                    : community.liked
+                    ? "text-red-500"
+                    : "text-gray-500"
+                }`}
+              >
+                <Heart
+                  size={22}
+                  className={
+                    community.liked
+                      ? "fill-red-500 text-red-500"
+                      : "text-gray-500"
+                  }
+                />
+                <span className="text-sm">{community.likeCount}</span>
+              </button>
+            </div>
+
+            {/* 댓글 섹션 */}
+            <div className="mt-8 p-4 bg-white rounded-xl shadow-sm border border-gray-100">
+              <h2 className="text-xl font-semibold mb-4">댓글</h2>
+
+              {/* 댓글 입력창 */}
+              <div className="flex gap-2 mb-4">
+                <input
+                  className="flex-1 p-2 border border-gray-200 rounded-lg focus:border-gray-300"
+                  placeholder="댓글을 입력하세요..."
+                  value={newComment}
+                  onChange={(e) => setNewComment(e.target.value)}
+                />
+                <button
+                  onClick={handleSubmitComment}
+                  className="px-4 py-2 bg-primary text-white rounded-lg"
+                >
+                  등록
+                </button>
+              </div>
+
+              {/* 댓글 리스트 */}
+              {comments.length === 0 ? (
+                <p className="text-gray-500">아직 댓글이 없습니다.</p>
+              ) : (
+                comments.map((c) => <div key={c.id}>{renderComment(c, 0)}</div>)
               )}
             </div>
           </div>

--- a/src/pages/community/CommunityListPage.jsx
+++ b/src/pages/community/CommunityListPage.jsx
@@ -66,11 +66,12 @@ export default function CommunityListPage() {
           {communities.length > 0 ? (
             communities.map((c) => (
               <CommunityCard
-                key={`community-${c.id}-${page}`}
                 title={c.title}
                 description={c.content}
                 image={c.imageUrl}
                 user={c.user}
+                likeCount={c.likeCount}
+                commentCount={c.commentCount}
                 onClick={() => navigate(`/community/${c.id}`)}
               />
             ))

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -1,0 +1,44 @@
+import api from "./api";
+
+// ⭐ 댓글 조회 (상위 댓글 + 대댓글 포함)
+export const getComments = async (communityId, page = 0, size = 10) => {
+  const response = await api.get(`/comments/${communityId}`, {
+    params: { page, size },
+  });
+  return response.data;
+};
+
+// ⭐ 댓글 작성 (일반 댓글 + 대댓글)
+export const createComment = async (body) => {
+  try {
+    const response = await api.post("/comments", body);
+    return response.data;
+  } catch (error) {
+    console.error("[createComment] Error:", error.response || error);
+    throw error;
+  }
+};
+
+// ⭐ 댓글 수정
+export const updateComment = async (commentId, body) => {
+  try {
+    const response = await api.patch(`/comments/${commentId}`, body, {
+      headers: { "Content-Type": "application/json" },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("[updateComment] Error:", error.response || error);
+    throw error;
+  }
+};
+
+// ⭐ 댓글 삭제
+export const deleteComment = async (commentId) => {
+  try {
+    const response = await api.delete(`/comments/${commentId}`);
+    return response.data;
+  } catch (error) {
+    console.error("[deleteComment] Error:", error.response || error);
+    throw error;
+  }
+};


### PR DESCRIPTION
---
title: "[Feat] 댓글, 좋아요 UI 추가"
---

> ### 🔍 관련 이슈
<!-- 연결된 이슈 번호를 적어주세요 (예: closes #45) -->
- closes #52

> ### 🧩 PR 요약
<!-- 어떤 작업을 했는지 간단히 설명해주세요 -->
- 자유 게시물에 달린 댓글과 좋아요 정보를 반환하게 했습니다.
- 댓글과 좋아요를 생성 혹은 취소할 수 있습니다.

> ### 🧱 변경 사항
<!-- 주요 코드 변경점을 리스트업 해주세요 -->
- [ ] commentService 추가
- [ ] communityListPage에 좋아요수, 댓글수 추가

> ### 🧪 테스트 결과
<!-- 로컬 또는 서버에서 테스트한 결과를 적어주세요 -->
1. 댓글 목록
<img width="511" height="808" alt="image" src="https://github.com/user-attachments/assets/ce5360d5-b697-4af9-b6c0-5e5aa362f7f1" />

2. 글 목록에서의 좋아요, 댓글 수 반환
<img width="494" height="148" alt="image" src="https://github.com/user-attachments/assets/8ae7fea0-58d1-4677-af01-dc6e7d75127f" />


> ### 🧠 참고 사항
<!-- 리뷰어가 알아두면 좋을 추가 내용, 의도, 고려 사항 등을 적어주세요 -->
- 수정 기능을 유사 사이트들 보면 수정하는 기능이 있는 경우도 있지만 수정보다 삭제만 이루어지는 로직들도 많은 거같아서 삭제만 넣어두었습니다. 그리고 수정 API는 일단 만들어두어서 넣어보려했는데 cors 설정이 생각보다 복잡해서 보류한 것도 있습니다.
- 조회수 기능은 백엔드 로직에서는 1시간 이내에 조회할 경우 조회수가 오르지 않게 구현되어 있으나 프론트와 연동하는 과정에서 잘 이루어지지 않아 우선 다시 주석 처리해두었습니다. 이부분은 다시 고쳐두도록 하겠습니다.
